### PR TITLE
Fixed issues

### DIFF
--- a/Documentation/AnalyzerRules/MM0006.md
+++ b/Documentation/AnalyzerRules/MM0006.md
@@ -1,0 +1,18 @@
+﻿# MM0006 :  Can not create mock for a sealed class
+
+MiniMock does not support creating mocks for sealed classes. This is because the MiniMock framework uses inheritance to create mocks. Sealed classes cannot be inherited from, so MiniMock cannot create a mock for a sealed class.
+
+The following code will raise this error:
+
+```csharp
+    public sealed class SealedClass
+    {
+        ///...
+    }
+    
+    [Mock<SealedClass>]
+    public void TestMethod()
+    {
+        //...
+    }    
+```

--- a/src/MiniMock/AnalyzerReleases.Unshipped.md
+++ b/src/MiniMock/AnalyzerReleases.Unshipped.md
@@ -1,10 +1,11 @@
-﻿## Release 0.9.1
+﻿## Release 0.9.5
 
 ### New Rules
 
-| Rule ID | Category            | Severity | Notes                                                                                                                                         |
-|---------|---------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| MM0002  | Unsupported feature | Error    | Ref properties not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0002.md)          |
-| MM0003  | Unsupported feature | Error    | Ref return type not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0003.md)         |
-| MM0004  | Unsupported feature | Error    | Generic method not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0004.md)          |
-| MM0005  | Unsupported feature | Error    | Static abstract members not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0005.md) |
+| Rule ID | Category            | Severity | Notes                                                                                                                                          |
+|---------|---------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| MM0002  | Unsupported feature | Error    | Ref properties not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0002.md)           |
+| MM0003  | Unsupported feature | Error    | Ref return type not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0003.md)          |
+| MM0004  | Unsupported feature | Error    | Generic method not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0004.md)           |
+| MM0005  | Unsupported feature | Error    | Static abstract members not supported, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0005.md)  |
+| MM0006  | Unsupported feature | Error    | Can not create mock for a sealed class, [Documentation](https://github.com/oswaldsql/MiniMock/blob/main/Documentation/AnalyzerRules/MM0006.md) |

--- a/src/MiniMock/Builders/ClassBuilder.cs
+++ b/src/MiniMock/Builders/ClassBuilder.cs
@@ -12,6 +12,11 @@ internal class ClassBuilder(ISymbol target)
 
     private string BuildClass()
     {
+        if (target.IsSealed)
+        {
+            throw new CanNotMockASealedClassException(target as INamedTypeSymbol);
+        }
+
         var builder = new CodeBuilder();
 
         var fullName = target.ToString();
@@ -42,7 +47,7 @@ internal class ClassBuilder(ISymbol target)
                       internal class {{name}} : {{fullName}} {{constraints}}
                       {
                       ->
-                      private {{target.Name}}Mock(System.Action<Config>? config = null) {
+                      internal protected {{target.Name}}Mock(System.Action<Config>? config = null) {
                           var result = new Config(this);
                           config = config ?? new System.Action<Config>(t => { });
                           config.Invoke(result);
@@ -54,7 +59,7 @@ internal class ClassBuilder(ISymbol target)
                       private Config _config { get; }
                       internal void GetConfig(out Config config) => config = _config;
 
-                      public partial class Config
+                      internal partial class Config
                       {
                           private readonly {{name}} target;
 

--- a/src/MiniMock/Builders/Helpers.cs
+++ b/src/MiniMock/Builders/Helpers.cs
@@ -40,7 +40,7 @@ public static class Helpers
 
         var signatures = helpers.ToLookup(t => t.Signature);
 
-        builder.Add("public partial class Config {").Indent();
+        builder.Add("internal partial class Config {").Indent();
 
         foreach (var grouping in signatures)
         {

--- a/src/MiniMock/Builders/MethodBuilder.cs
+++ b/src/MiniMock/Builders/MethodBuilder.cs
@@ -72,7 +72,7 @@ internal static class MethodBuilder
                       }
                       private {{functionPointer}}_Delegate {{functionPointer}} {get;set;} = ({{parameterList}}) => {{symbol.BuildNotMockedException()}}
 
-                      public partial class Config{
+                      internal partial class Config{
                           private Config {{functionPointer}}({{functionPointer}}_Delegate call){
                               target.{{functionPointer}} = call;
                               return this;

--- a/src/MiniMock/Builders/MockClassBuilder.cs
+++ b/src/MiniMock/Builders/MockClassBuilder.cs
@@ -75,43 +75,4 @@ public static class MockClassBuilder
 
         return builder.ToString();
     }
-
-    //private static string Constraints(ImmutableArray<ITypeSymbol> typeArguments)
-    //{
-    //    var result = new StringBuilder();
-    //
-    //    foreach (var s in typeArguments.Select(type => BuildConstraintsString((ITypeParameterSymbol)type)))
-    //    {
-    //        result.Append(s);
-    //    }
-    //
-    //    return result.ToString().Trim();
-    //}
-    //
-    //private static string BuildConstraintsString(ITypeParameterSymbol symbol)
-    //{
-    //    var result = new List<string>();
-    //
-    //    foreach (var t in symbol.ConstraintTypes)
-    //    {
-    //        result.Add(t.ToString());
-    //    }
-    //
-    //    if (symbol.HasUnmanagedTypeConstraint)
-    //    {
-    //        result.Add("unmanaged");
-    //    }
-    //    else
-    //    {
-    //        if (symbol.HasConstructorConstraint) result.Add("new()");
-    //        if(symbol.HasValueTypeConstraint) result.Add("struct");
-    //    }
-    //
-    //    if(symbol.HasReferenceTypeConstraint) result.Add("class");
-    //    if(symbol.HasNotNullConstraint) result.Add("notnull");
-    //
-    //    if (result.Count == 0) { return "";}
-    //
-    //    return " where " + symbol.Name + " : " + string.Join(", ", result);
-    //}
 }

--- a/src/MiniMock/DiagnosticsBuilder.cs
+++ b/src/MiniMock/DiagnosticsBuilder.cs
@@ -14,49 +14,50 @@ internal static class DiagnosticsBuilder
         ITypeSymbol sourceType) =>
         context.ReportDiagnostic(Diagnostic.Create(Mm0001, locations.FirstOrDefault(), sourceType));
 
-    private static readonly DiagnosticDescriptor Mm0002 = new("MM0002", "Unsupported feature",
-        "{0}", "MiniMock", DiagnosticSeverity.Error,
-        true);
-
+    private static readonly DiagnosticDescriptor Mm0002 = new("MM0002", "Unsupported feature", "{0}", "MiniMock", DiagnosticSeverity.Error, true);
     public static void AddRefPropertyNotSupported(this SourceProductionContext context, IEnumerable<Location> locations, string message)
     {
-        var l = locations.ToArray();
-        var diagnostic = Diagnostic.Create(Mm0002, l.FirstOrDefault(), l.Skip(1), message);
-        context.ReportDiagnostic(diagnostic);
+        foreach (var l in locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Mm0002, l, message));
+        }
     }
 
 
-    private static readonly DiagnosticDescriptor Mm0003 = new("MM0003", "Unsupported feature",
-        "{0}", "MiniMock", DiagnosticSeverity.Error,
-        true);
-
+    private static readonly DiagnosticDescriptor Mm0003 = new("MM0003", "Unsupported feature", "{0}", "MiniMock", DiagnosticSeverity.Error, true);
     public static void AddRefReturnTypeNotSupported(this SourceProductionContext context, IEnumerable<Location> locations, string message)
     {
-        var l = locations.ToArray();
-        var diagnostic = Diagnostic.Create(Mm0003, l.FirstOrDefault(), l.Skip(1), message);
-        context.ReportDiagnostic(diagnostic);
+        foreach (var l in locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Mm0003, l, message));
+        }
     }
 
 
-    private static readonly DiagnosticDescriptor Mm0004 = new("MM0004", "Unsupported feature",
-        "{0}", "MiniMock", DiagnosticSeverity.Error,
-        true);
-
+    private static readonly DiagnosticDescriptor Mm0004 = new("MM0004", "Unsupported feature", "{0}", "MiniMock", DiagnosticSeverity.Error, true);
     public static void AddGenericMethodNotSupported(this SourceProductionContext context, IEnumerable<Location> locations, string message)
     {
-        var l = locations.ToArray();
-        var diagnostic = Diagnostic.Create(Mm0004, l.FirstOrDefault(), l.Skip(1), message);
-        context.ReportDiagnostic(diagnostic);
+        foreach (var l in locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Mm0004, l, message));
+        }
     }
 
-    private static readonly DiagnosticDescriptor Mm0005 = new("MM0005", "Unsupported feature",
-        "{0}", "MiniMock", DiagnosticSeverity.Error,
-        true);
-
+    private static readonly DiagnosticDescriptor Mm0005 = new("MM0005", "Unsupported feature", "{0}", "MiniMock", DiagnosticSeverity.Error, true);
     public static void AddStaticAbstractMembersNotSupported(this SourceProductionContext context, IEnumerable<Location> locations, string message)
     {
-        var l = locations.ToArray();
-        var diagnostic = Diagnostic.Create(Mm0005, l.FirstOrDefault(), l.Skip(1), message);
-        context.ReportDiagnostic(diagnostic);
+        foreach (var l in locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Mm0005, l, message));
+        }
+    }
+
+    private static readonly DiagnosticDescriptor Mm0006 = new("MM0006", "Unsupported feature", "{0}", "MiniMock", DiagnosticSeverity.Error, true);
+    public static void CanNotMockASealedClass(this SourceProductionContext context, IEnumerable<Location> locations, string message)
+    {
+        foreach (var l in locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Mm0006, l, message));
+        }
     }
 }

--- a/src/MiniMock/MiniMock.csproj
+++ b/src/MiniMock/MiniMock.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
     <Title>Mini mock</Title>
     <Authors>Lasse Sjørup</Authors>
     <Description>A minimalistic source generator for creating mocks for testing is a tool that automatically generates mock implementations of interfaces or classes. This helps in unit testing by providing a way to simulate the behavior of complex dependencies.</Description>

--- a/src/MiniMock/MiniMockGenerator.cs
+++ b/src/MiniMock/MiniMockGenerator.cs
@@ -59,6 +59,10 @@ public sealed class MiniMockGenerator : IIncrementalGenerator
                 {
                     context.AddStaticAbstractMembersNotSupported(GetSourceLocations(source), e.Message);
                 }
+                catch (CanNotMockASealedClassException e)
+                {
+                    context.CanNotMockASealedClass(GetSourceLocations(source), e.Message);
+                }
 
             }
         }
@@ -84,3 +88,4 @@ internal class RefPropertyNotSupportedException(IPropertySymbol propertySymbol, 
 internal class RefReturnTypeNotSupportedException(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol) : Exception($"Ref return type not supported for '{methodSymbol.Name}' in '{typeSymbol.Name}'" );
 internal class GenericMethodNotSupportedException(IMethodSymbol methodSymbol, ITypeSymbol typeSymbol) : Exception($"Generic methods in non generic interfaces or classes is not currently supported for '{methodSymbol.Name}' in '{typeSymbol.Name}'" );
 internal class StaticAbstractMembersNotSupportedException(string name, ITypeSymbol typeSymbol) : Exception($"Static abstract members in interfaces or classes is not supported for '{name}' in '{typeSymbol.Name}'" );
+internal class CanNotMockASealedClassException(ITypeSymbol typeSymbol) : Exception($"Cannot mock the sealed class '{typeSymbol.Name}'" );

--- a/tests/MiniMock.Tests/Demo.cs
+++ b/tests/MiniMock.Tests/Demo.cs
@@ -30,7 +30,7 @@ public class Demo(ITestOutputHelper testOutputHelper)
                 .DownloadExists(throws: new IndexOutOfRangeException()) // Throws IndexOutOfRangeException for all versions
                 .DownloadExists(call: s => s.StartsWith("2.0.0")) // Returns true for version 2.0.0.x base on a string parameter
                 .DownloadExists(call: v => v is { Major: 2, Minor: 0, Revision: 0 }) // Returns true for version 2.0.0.x based on a version parameter
-                .DownloadExists([true, true, false]) // Returns true two times, then false
+                .DownloadExists(returns: [true, true, false]) // Returns true two times, then false
 
                 .DownloadLinkAsync(returns: Task.FromResult(new Uri("http://downloads/2.0.0"))) // Returns a task containing a download link for all versions
                 .DownloadLinkAsync(call: s => Task.FromResult(s.StartsWith("2.0.0") ? new Uri("http://downloads/2.0.0") : new Uri("http://downloads/UnknownVersion"))) // Returns a task containing a download link for version 2.0.0.x otherwise a error link

--- a/tests/MiniMock.Tests/MethodTests/MultipleReturnValuesTests.cs
+++ b/tests/MiniMock.Tests/MethodTests/MultipleReturnValuesTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MiniMock.Tests.MethodTests;
+namespace MiniMock.Tests.MethodTests;
 
 [Mock<IMultipleReturnValues>]
 public class MultipleReturnValuesTests
@@ -33,7 +33,8 @@ public class MultipleReturnValuesTests
     public async Task ItShouldBePossibleToSpecifyMultipleReturnValuesForAsyncMethods()
     {
         // Arrange
-        var sut = Mock.IMultipleReturnValues(config => config.MethodAsync([Task.FromResult("1"), Task.FromResult("2"), Task.FromResult("3")]));
+        var sut = Mock.IMultipleReturnValues(config =>
+            config.MethodAsync([Task.FromResult("1"), Task.FromResult("2"), Task.FromResult("3")]));
 
         // Act
         var token = CancellationToken.None;
@@ -66,7 +67,11 @@ public class MultipleReturnValuesTests
     public void EmptyValuesAreAllowedAndDefaultsToThrowException()
     {
         // Arrange
-        var sut = Mock.IMultipleReturnValues(config => config.Method([]));
+        var enumerable = new string [] {};
+        var sut = Mock.IMultipleReturnValues(config =>
+        {
+            config.Method(enumerable);
+        });
 
         // Act
         var shouldFail = Assert.Throws<InvalidOperationException>(() => sut.Method());
@@ -79,7 +84,7 @@ public class MultipleReturnValuesTests
     public void MultipleValuesAreSetIndividuallyOnEachMethod()
     {
         // Arrange
-        var sut = Mock.IMultipleReturnValues(config => config.Method(["1","2","3"]));
+        var sut = Mock.IMultipleReturnValues(config => config.Method(["1", "2", "3"]));
 
         // ACT
         var first = sut.Method();
@@ -87,14 +92,14 @@ public class MultipleReturnValuesTests
 
         // Assert
         Assert.Equal("1", first);
-        Assert.Equal("1",CallToMethodWithParameter);
+        Assert.Equal("1", CallToMethodWithParameter);
     }
 
     [Fact]
     public void ItShouldBePossibleToSpecifyMultipleReturnValue()
     {
         // Arrange
-        var sut = Mock.IMultipleReturnValues(config => config.Method(["1","2","3"]).MethodAsync(["1","2","3"]));
+        var sut = Mock.IMultipleReturnValues(config => config.Method(["1", "2", "3"]).MethodAsync(["1", "2", "3"]));
 
         // ACT
         var first = sut.Method();
@@ -110,6 +115,6 @@ public class MultipleReturnValuesTests
         Assert.Equal("3", third);
         Assert.NotNull(shouldFail);
 
-        Assert.Equal("1",CallToMethodWithParameter);
+        Assert.Equal("1", CallToMethodWithParameter);
     }
 }

--- a/tests/MiniMock.Tests/MethodTests/TaskMethodTests.cs
+++ b/tests/MiniMock.Tests/MethodTests/TaskMethodTests.cs
@@ -1,6 +1,5 @@
 namespace MiniMock.Tests.MethodTests;
 using System;
-using System.Collections.Frozen;
 using System.Threading.Tasks;
 
 [Mock<IAsyncTaskMethods>]

--- a/tests/MiniMock.UnitTests/ConfigClassTests.cs
+++ b/tests/MiniMock.UnitTests/ConfigClassTests.cs
@@ -62,7 +62,7 @@ public class ConfigClassTests(ITestOutputHelper testOutputHelper)
         testOutputHelper.DumpResult(generate);
 
         Assert.True(generate.diagnostics.HasErrors());
-        Assert.Contains(generate.GetErrors(), t => t.Id == "CS0509"); // Inheritance of sealed class is not allowed
+        Assert.Contains(generate.GetErrors(), t => t.Id == "MM0006"); // Inheritance of sealed class is not allowed
     }
 
     internal abstract class AbstractClass

--- a/tests/MiniMock.UnitTests/DiagnosticsTests.cs
+++ b/tests/MiniMock.UnitTests/DiagnosticsTests.cs
@@ -49,4 +49,27 @@ public class DiagnosticsTests(ITestOutputHelper testOutputHelper)
 
         Assert.Equal("Mock<MiniMock.UnitTests.DiagnosticsTests.IRefMethod>", actual.Location.GetCode());
     }
+
+    public sealed class SealedClass
+    {
+    }
+
+    [Fact]
+    public void MockingSealedClasesWillRaiseTheMM0006Error()
+    {
+        var source = Build.TestClass<SealedClass>();
+
+        var generate = new MiniMockGenerator().Generate(source);
+
+        testOutputHelper.DumpResult(generate);
+
+        var diagnostics = generate.GetErrors();
+
+        var actual = Assert.Single(diagnostics);
+        Assert.Equal(DiagnosticSeverity.Error, actual.Severity);
+        Assert.Equal("MM0006", actual.Id);
+        Assert.Equal("Cannot mock the sealed class 'SealedClass'", actual.GetMessage());
+
+        Assert.Equal("Mock<MiniMock.UnitTests.DiagnosticsTests.SealedClass>", actual.Location.GetCode());
+    }
 }


### PR DESCRIPTION
- #15 Change CTOR for mock object to internal protected to allow for inheriting mocks
- #16 Change config class to internal
- #17 Do not try to mock sealed classes. Raise a error (MM0006)

Created release 0.9.6